### PR TITLE
fix calendar links not working

### DIFF
--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -78,14 +78,14 @@ layout: layout
                         </div>
 
                         {% capture url_google_calendar  %}https://www.google.com/calendar/render?action=TEMPLATE
-    {% if event.title %}&text={{ event.title|uri_escape }}{% endif %}
-    &dates={{ event.event_date|date: '%Y%m%dT%H%M00'}}/{{ event.event_date|date: '%Y%m%dT%H%M00'}}
-    {% if event.description %}
-    &details={{ event.description|markdownify|strip_html|uri_escape }}
-    {% endif %}
-    {% if event.location %}
-    &location={{ event.location.name|append:''|uri_escape }}+{{ event.location.street_address|uri_escape }}+{{ event.location.postal_code }}+{{ event.location.city|uri_escape }}{% endif %}
-    &sf=true{% endcapture %}
+{% if event.title %}&text={{ event.title|uri_escape }}{% endif %}
+&dates={{ event.event_date|date: '%Y%m%dT%H%M00'}}/{{ event.event_date|date: '%Y%m%dT%H%M00'}}
+{% if event.description %}
+&details={{ event.description|markdownify|strip_html|uri_escape }}
+{% endif %}
+{% if event.location %}
+&location={{ event.location.name|append:''|uri_escape }}+{{ event.location.street_address|uri_escape }}+{{ event.location.postal_code }}+{{ event.location.city|uri_escape }}{% endif %}
+&sf=true{% endcapture %}
 
                         <div class="event-add-calendar">
                             <i class="fa fa-google event-meta-icon"></i>
@@ -95,22 +95,22 @@ layout: layout
                         </div>
 
                         {% capture icalendar_data %}BEGIN:VCALENDAR\r\n
-    PRODID:planet.clermontech.org\r\n
-    VERSION:2.0\r\n
-    BEGIN:VEVENT\r\n
-    UID:{{ event.id|remove_first:'/'|replace:'/','-' }}\r\n
-    DTSTART:{{ event.event_date|date: '%Y%m%dT%H%M00' }}\r\n
-    {% if event.title %}
-    SUMMARY:{{ event.title }}\r\n{% endif %}
-    {% if event.location %}
-    LOCATION:{{ event.location.name }} {{ event.location.street_address }} {{ event.location.postal_code }} {{ event.location.city }}\r\n
-    {% endif %}
-    {% if event.description %}
-    DESCRIPTION:{{ event.description|markdownify|replace:'<br>':'\\\n'|strip_html|replace:',','\\,' }}\r\n
-    {% endif %}
-    CATEGORIES:{{ event.tags|join:','|replace: "'","\\'" }}\r\n
-    END:VEVENT\r\n
-    END:VCALENDAR{% endcapture %}
+PRODID:planet.clermontech.org\r\n
+VERSION:2.0\r\n
+BEGIN:VEVENT\r\n
+UID:{{ event.id|remove_first:'/'|replace:'/','-' }}\r\n
+DTSTART:{{ event.event_date|date: '%Y%m%dT%H%M00' }}\r\n
+{% if event.title %}
+SUMMARY:{{ event.title }}\r\n{% endif %}
+{% if event.location %}
+LOCATION:{{ event.location.name }} {{ event.location.street_address }} {{ event.location.postal_code }} {{ event.location.city }}\r\n
+{% endif %}
+{% if event.description %}
+DESCRIPTION:{{ event.description|markdownify|replace:'<br>':'\\\n'|strip_html|replace:',','\\,' }}\r\n
+{% endif %}
+CATEGORIES:{{ event.tags|join:','|replace: "'","\\'" }}\r\n
+END:VEVENT\r\n
+END:VCALENDAR{% endcapture %}
 
                         <div class="event-add-calendar">
                             <i class="fa fa-calendar event-meta-icon"></i>


### PR DESCRIPTION
J'ai remarqué que les liens `google calendar` et `icalendar` ne fonctionnaient plus. Il s'est avéré que ça provenait simplement d'une tabulation en plus.
