### PR TITLE
'sticky' footer

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -47,7 +47,7 @@
         </section>
     </nav>
 
-    <header>
+    <header class="page-row">
         <hgroup class="row">
             <div class="large-12 columns">
                 <a href="{{page.baseurl}}/">
@@ -62,11 +62,11 @@
         </div>
     </header>
 
-    <section id="content">
+    <section id="content" class="page-row page-row-expanded">
         {{ content }}
     </section>
 
-    <footer>
+    <footer class="page-row">
         <div class="row">
             <div class="small-12 columns">
                 {{ site.footer|markdownify }}

--- a/css/main.css
+++ b/css/main.css
@@ -11793,60 +11793,78 @@ meta.foundation-mq-topbar {
 }
 
 /* line 12, ../scss/_page.scss */
+html, body {
+  height: 100%;
+}
+
+/* line 16, ../scss/_page.scss */
 body {
   font-family: Raleway, "Helvetica Neue", Helvetica, Arial, sans-serif;
   background-color: white;
+  display: table;
+  width: 100%;
 }
 
-/* line 17, ../scss/_page.scss */
+/* line 23, ../scss/_page.scss */
+.page-row {
+  display: table-row;
+  height: 1px;
+}
+
+/* line 28, ../scss/_page.scss */
+.page-row-expanded {
+  height: 100%;
+}
+
+/* line 30, ../scss/_page.scss */
 h2, h1, .title-area strong, h3, h4, h5, h6 {
   font-family: "Neutraface Bold", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
-/* line 21, ../scss/_page.scss */
+/* line 34, ../scss/_page.scss */
 h2, h1, .title-area strong {
   font-weight: bold;
 }
 
-/* line 26, ../scss/_page.scss */
+/* line 39, ../scss/_page.scss */
 h1, .title-area strong {
   text-transform: uppercase;
 }
 
-/* line 31, ../scss/_page.scss */
+/* line 44, ../scss/_page.scss */
 h2, h1, .title-area strong {
   color: white;
   text-align: left;
 }
 
-/* line 41, ../scss/_page.scss */
+/* line 54, ../scss/_page.scss */
 header {
   background-color: #222222;
   margin-bottom: 10px;
 }
 
-/* line 46, ../scss/_page.scss */
+/* line 59, ../scss/_page.scss */
 hgroup {
   display: none;
 }
 
-/* line 50, ../scss/_page.scss */
+/* line 63, ../scss/_page.scss */
 hr {
   display: block;
 }
 
-/* line 54, ../scss/_page.scss */
+/* line 67, ../scss/_page.scss */
 img {
   display: inline-block;
 }
 
-/* line 58, ../scss/_page.scss */
+/* line 71, ../scss/_page.scss */
 li {
   text-align: center;
   background-color: #222222;
 }
 
-/* line 63, ../scss/_page.scss */
+/* line 76, ../scss/_page.scss */
 .rss-link {
   display: none;
   max-width: 62.5rem;
@@ -11854,62 +11872,62 @@ li {
   text-align: right;
   height: 0px;
 }
-/* line 70, ../scss/_page.scss */
+/* line 83, ../scss/_page.scss */
 .rss-link .fa-rss {
   color: white;
   bottom: 29px;
   padding-right: 15px;
   position: relative;
 }
-/* line 76, ../scss/_page.scss */
+/* line 89, ../scss/_page.scss */
 .rss-link .fa-rss:hover {
   color: #008CBA;
 }
 
-/* line 82, ../scss/_page.scss */
+/* line 95, ../scss/_page.scss */
 .top-bar {
   height: 40px;
   background-color: #222222;
 }
-/* line 86, ../scss/_page.scss */
+/* line 99, ../scss/_page.scss */
 .top-bar .toggle-topbar.menu-icon {
   margin: 0;
   top: 0%;
 }
-/* line 90, ../scss/_page.scss */
+/* line 103, ../scss/_page.scss */
 .top-bar .toggle-topbar.menu-icon a {
   height: 40px;
 }
 
-/* line 96, ../scss/_page.scss */
+/* line 109, ../scss/_page.scss */
 .top-bar.expanded {
   background-color: #222222;
 }
 
-/* line 100, ../scss/_page.scss */
+/* line 113, ../scss/_page.scss */
 .top-bar-section {
   z-index: 999;
   margin: 0px auto;
   max-width: 62.5rem;
   width: auto;
 }
-/* line 110, ../scss/_page.scss */
+/* line 123, ../scss/_page.scss */
 .top-bar-section li:not(.has-form) a {
   font-family: "Neutraface Bold", "Helvetica Neue", Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   font-weight: bold;
   font-size: 1.0em;
 }
-/* line 116, ../scss/_page.scss */
+/* line 129, ../scss/_page.scss */
 .top-bar-section li:not(.has-form) a:not(.button) {
   background-color: #222222;
 }
-/* line 119, ../scss/_page.scss */
+/* line 132, ../scss/_page.scss */
 .top-bar-section li:not(.has-form) a:not(.button):hover {
   background-color: #30303f;
 }
 
-/* line 130, ../scss/_page.scss */
+/* line 143, ../scss/_page.scss */
 .title-area strong {
   margin-top: 0px;
   display: block;
@@ -11920,7 +11938,7 @@ li {
   font-size: 1.5em;
 }
 
-/* line 142, ../scss/_page.scss */
+/* line 155, ../scss/_page.scss */
 .logo-small {
   margin: 8px 0px;
   margin-left: 10px;
@@ -11929,23 +11947,22 @@ li {
   z-index: 1;
 }
 
-/* line 150, ../scss/_page.scss */
+/* line 163, ../scss/_page.scss */
 #content {
   min-height: 60%;
 }
 
-/* line 154, ../scss/_page.scss */
+/* line 167, ../scss/_page.scss */
 footer {
   width: 100%;
   background: #222222;
-  padding-top: 30px;
-  padding-bottom: 10px;
   color: white;
 }
-/* line 161, ../scss/_page.scss */
+/* line 172, ../scss/_page.scss */
 footer p {
   text-align: justify;
   font-size: 0.9em;
+  margin: 20px 0;
 }
 
 /*

--- a/scss/_page.scss
+++ b/scss/_page.scss
@@ -8,11 +8,24 @@ meta.foundation-mq-topbar {
   font-family: "/only screen and (min-width:64.063em)/";
   width: 64.063em;
 }
- 
+
+html, body{
+    height: 100%;
+}
+
 body {
     font-family: $default_font;
     background-color: $background_color;
+    display: table;
+    width: 100%;
 }
+
+.page-row {
+display: table-row;
+height: 1px;
+}
+ 
+.page-row-expanded { height: 100%; } 
 
 %h_mother {
     font-family: $title_font;
@@ -154,12 +167,11 @@ li {
 footer {
     width: 100%;
     background: $footer_background_color;
-    padding-top: 30px;
-    padding-bottom: 10px;
     color: $background_color;
 
     p {
         text-align: justify;
         font-size: 0.9em;
+        margin: 20px 0;
     }
 }


### PR DESCRIPTION
Voilà une technique qui permet au `footer` de 'stick' au bas de la page quand le content est trop petit.
C'est la seule technique que j'ai trouvé qui n'implique pas un `footer` avec une taille fixe ou une `position: absolute`.

Voilà le rendu : 
![sticky-footer](https://cloud.githubusercontent.com/assets/9320027/5391589/1c4e6ed4-811d-11e4-926b-f3061c28f185.png)

![sticky-footer2](https://cloud.githubusercontent.com/assets/9320027/5391593/204e6c3c-811d-11e4-8549-6c0578dd7aee.png)
