### PR TITLE
Update dependencies with `bundle update`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    activesupport (5.1.4)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
@@ -25,7 +25,7 @@ GEM
       timers (>= 4.1.1)
     celluloid-supervision (0.20.6)
       timers (>= 4.1.1)
-    chunky_png (1.3.8)
+    chunky_png (1.3.10)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -45,12 +45,12 @@ GEM
       sass (>= 3.2, < 3.5)
     compass-validator (3.0.1)
     concurrent-ruby (1.0.5)
-    ethon (0.10.1)
+    ethon (0.11.0)
       ffi (>= 1.3.0)
     execjs (2.7.0)
-    faraday (0.13.1)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     font-awesome-sass (4.2.2)
       sass (~> 3.2)
     foundation (1.0.4)
@@ -85,11 +85,12 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 1.4)
       typhoeus (~> 0.7)
-    hitimes (1.2.6)
-    html-pipeline (2.7.1)
+    hitimes (1.3.0)
+    html-pipeline (2.8.4)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    i18n (0.8.6)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     jekyll (3.0.4)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
@@ -133,16 +134,16 @@ GEM
       rb-inotify (>= 0.9)
     mercenary (0.3.6)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
-    multi_json (1.12.2)
+    minitest (5.11.3)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    octokit (4.7.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (1.5.3)
-    rb-fsevent (0.10.2)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdiscount (2.1.8)
@@ -161,9 +162,9 @@ GEM
       hitimes
     typhoeus (0.8.0)
       ethon (>= 0.8.0)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -178,4 +179,4 @@ DEPENDENCIES
   sass (~> 3.3.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.2


### PR DESCRIPTION
Update Ruby dependencies with `bundle update` (references issue #210)

There are still some packages that are listed as "out of date" but will not upgrade with bundler without potentially breaking changes (semver restrictions)
