### PR TITLE
remove `exec` from the docker commend line

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ docker build --rm -t planet-clermontech .
 ```
 
 ```
-$ docker run --rm -ti -p 4000:4000 -v $PWD:/srv planet-clermontech exec jekyll serve --host=0.0.0.0
+$ docker run --rm -ti -p 4000:4000 -v $PWD:/srv planet-clermontech jekyll serve --host=0.0.0.0
 ```


### PR DESCRIPTION
```sh
$ docker run --rm -ti -p 4000:4000 -v $PWD:/srv planet-clermontech exec jekyll serve --host=0.0.0.0
docker: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"exec\": executable file not found in $PATH": unknown.
```