### PR TITLE
Ajout de aPEERo #26

### DIFF
--- a/content/posts/2026-07-02-auvernix-apeero-026.md
+++ b/content/posts/2026-07-02-auvernix-apeero-026.md
@@ -1,0 +1,19 @@
++++ tags = ["AuvernIX", "aPEERo"]
+
+[params]
+
+[params.event] name = "aPEERo #26 par FRNIX♥AuvernIX" date = "2026-07-02 19:00:00" is_free = true event_url = "https://frnix.org/events/apeero-026/" [params.event.location] friendly_name = "Restaurant Le Carnivore" full_address = "20 rue Albert Evaux,
+63119 Châteaugay"
+
+[params.organizer] name = "FRNIX + AuvernIX" website = "https://auvernix.org" +++
+
+FRNIX vous convie à ses rendez-vous mensuels incontournables !
+
+Chaque mois et dans une ville différente, un sponsor a l'opportunité de présenter son activité de manière dynamique et engageante. C’est l’occasion idéale de découvrir de nouvelles entreprises, des produits innovants et des services pertinents pour votre secteur.
+
+Après la présentation, place à la convivialité !
+Participez à un moment de réseautage informel autour d’une bière fraîche, échangez avec les autres participants, créez des liens professionnels durables et explorez de nouvelles collaborations.
+
+La soirée est organisée en collaboration avec [AuvernIX](https://auvernix.org/). AuvernIX est une association à but non lucratif qui gère le premier point d’échange Internet (IXP) d’Auvergne & du Massif Central depuis 2012.
+
+La soirée est sponsorisée par [UltraEdge](https://www.ultraedge.com/) et [Zoréole](https://www.zoreole.com/).


### PR DESCRIPTION
AuvernIX co-organise un aPEERo avec FRNIX.
Un aPEERo est une soirée d'échange et de rencontre pour les personnes qui ont les réseaux et les télécoms pour centres d’intérêts 